### PR TITLE
Result monad

### DIFF
--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0C0161191FC7477700D23BAB /* Result.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C0161181FC7477700D23BAB /* Result.swift */; };
 		0C1203B01F2163A30032A9AD /* NSObject+Core.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C1203AF1F2163A30032A9AD /* NSObject+Core.swift */; };
 		0C560B301EECF75600719807 /* CpfUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C560B2F1EECF75600719807 /* CpfUtil.swift */; };
 		0C56FE511F2012CD000B15C2 /* FileUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C56FE501F2012CD000B15C2 /* FileUtil.swift */; };
@@ -62,6 +63,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		0C0161181FC7477700D23BAB /* Result.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Result.swift; sourceTree = "<group>"; };
 		0C1203AF1F2163A30032A9AD /* NSObject+Core.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSObject+Core.swift"; sourceTree = "<group>"; };
 		0C560B2F1EECF75600719807 /* CpfUtil.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CpfUtil.swift; sourceTree = "<group>"; };
 		0C56FE501F2012CD000B15C2 /* FileUtil.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileUtil.swift; sourceTree = "<group>"; };
@@ -347,6 +349,7 @@
 			isa = PBXGroup;
 			children = (
 				0C91DD821EE5E5E600F9F19D /* MochaLogger.swift */,
+				0C0161181FC7477700D23BAB /* Result.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -584,6 +587,7 @@
 			files = (
 				0C91DD831EE5E5E600F9F19D /* MochaException.swift in Sources */,
 				0C5ECB7D1F1EC91B00ABCD5A /* DateUtil.swift in Sources */,
+				0C0161191FC7477700D23BAB /* Result.swift in Sources */,
 				0C5ECB881F1ED2D000ABCD5A /* MochaTaskManager.swift in Sources */,
 				0C91DD6F1EE5DBA600F9F19D /* KeyboardUtil.swift in Sources */,
 				0C91DD6D1EE5DACD00F9F19D /* AppUtil.swift in Sources */,

--- a/Example/Tests/Network/HttpHelperTest.swift
+++ b/Example/Tests/Network/HttpHelperTest.swift
@@ -19,10 +19,10 @@ class HttpHelperTest: XCTestCase {
     
     func testRequestWithoutUrl() {
         let expect = expectation(description: "HttpHelper returns data through closure.")
-        var response : (data: Data?, error: Error?)?
+        var response : Result<Data>!
         
-        let handler = { (data: Data?, error: Error?) in
-            response = (data, error)
+        let handler = { (result: Result<Data>) in
+            response = result
             expect.fulfill()
         }
         
@@ -30,16 +30,30 @@ class HttpHelperTest: XCTestCase {
         httpHelper.get()
         
         waitForExpectations(timeout: 60) { error in
-            XCTAssertTrue(response?.error != nil)
+            if error != nil {
+                XCTAssert(false)
+            }
+            
+            switch response! {
+            case .failure(let error):
+                switch error {
+                case .domainException(_):
+                    XCTAssert(true)
+                default:
+                    XCTAssert(false)
+                }
+            case .success(_):
+                XCTAssert(false)
+            }
         }
     }
     
     func testGet() {
         let expect = expectation(description: "HttpHelper returns data through closure.")
-        var response : (data: Data?, error: Error?)?
+        var response : Result<Data>!
         
-        let handler = { (data: Data?, error: Error?) in
-            response = (data, error)
+        let handler = { (result: Result<Data>) in
+            response = result
             expect.fulfill()
         }
         
@@ -47,11 +61,12 @@ class HttpHelperTest: XCTestCase {
         httpHelper.get()
         
         waitForExpectations(timeout: 5) { error in
-            if let error = response?.error {
-                XCTFail(error.localizedDescription)
+            switch response! {
+            case .failure(_):
+                XCTAssert(false)
+            case .success(_):
+                XCTAssert(true)
             }
-            
-            XCTAssertTrue(response?.data != nil)
         }
     }
     

--- a/MochaUtilities/Classes/Basic/Enums/MochaException.swift
+++ b/MochaUtilities/Classes/Basic/Enums/MochaException.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public enum MochaException : Error {
+public enum MochaException : Error, Equatable {
     
     case ioException
     case fileNotFoundException
@@ -18,4 +18,20 @@ public enum MochaException : Error {
     case illegalStateException(message: String)
     case domainException(message: String)
     case genericException(message: String)
+    
+    public static func ==(lhs: MochaException, rhs: MochaException) -> Bool {
+        switch (lhs, rhs) {
+        case (.ioException, .ioException): return true
+        case (.fileNotFoundException, .fileNotFoundException): return true
+        case (.appSecurityTransportException, .appSecurityTransportException): return true
+        case (.notImplemented, .notImplemented): return true
+        case (.illegalStateException(let lmsg),
+              .illegalStateException(let rmsg)): return lmsg == rmsg
+        case (.domainException(let lmsg),
+              .domainException(let rmsg)): return lmsg == rmsg
+        case (.genericException(let lmsg),
+              .genericException(let rmsg)): return lmsg == rmsg
+        default: return false
+        }
+    }
 }

--- a/MochaUtilities/Classes/Basic/Helpers/Result.swift
+++ b/MochaUtilities/Classes/Basic/Helpers/Result.swift
@@ -1,0 +1,56 @@
+//
+//  Result.swift
+//  MochaUtilities
+//
+//  Created by Gregory Sholl e Santos on 23/11/17.
+//
+
+import Foundation
+
+public enum Result<T> {
+    case success(T)
+    case failure(MochaException)
+}
+
+public extension Result {
+    
+    public func map<U>(_ transform: (T) -> U) -> Result<U> {
+        switch self {
+        case .failure(let fluigError):
+            return .failure(fluigError)
+        case .success(let value):
+            return .success(transform(value))
+        }
+    }
+    
+    public func flatMap<U>(_ transform: (T) -> Result<U>) -> Result<U> {
+        switch self {
+        case .failure(let error):
+            return .failure(error)
+        case .success(let value):
+            return transform(value)
+        }
+    }
+}
+
+public func ==<T: Equatable>(lhs: Result<T>, rhs: Result<T>) -> Bool {
+    switch (lhs, rhs) {
+    case (.failure(let leftError), .failure(let rightError)):
+        return leftError == rightError
+    case (.success(let leftValue), .success(let rightValue)):
+        return leftValue == rightValue
+    default:
+        return false
+    }
+}
+
+public func == (lhs: Result<Void>, rhs: Result<Void>) -> Bool {
+    switch (lhs, rhs) {
+    case (.failure(let leftError), .failure(let rightError)):
+        return leftError == rightError
+    case (.success, .success):
+        return true
+    default:
+        return false
+    }
+}

--- a/MochaUtilities/Classes/Core/Utils/BundleUtil.swift
+++ b/MochaUtilities/Classes/Core/Utils/BundleUtil.swift
@@ -31,12 +31,12 @@ public class BundleUtil {
 
 public extension BundleUtil {
     
-    public func file(_ filename: String?, ofType type: String?) throws -> Data {
+    public func file(_ filename: String?, ofType type: String?) -> Result<Data> {
         let path = try self.path(of: filename, ofType: type)
         guard let fileData = try? Data(contentsOf: URL(fileURLWithPath: path)) else {
-            throw MochaException.fileNotFoundException
+            return .failure(.fileNotFoundException)
         }
-        return fileData
+        return .success(fileData)
     }
 }
 
@@ -44,18 +44,18 @@ public extension BundleUtil {
 
 public extension BundleUtil {
     
-    public func path(of filename: String?, ofType type: String?) throws -> String {
+    public func path(of filename: String?, ofType type: String?) -> Result<String> {
         guard let path = bundle.path(forResource: filename, ofType: type) else {
-            throw MochaException.fileNotFoundException
+            return .failure(.fileNotFoundException)
         }
-        return path
+        return .success(path)
     }
     
-    public func resourcePath(of filename: String) throws -> String {
+    public func resourcePath(of filename: String) -> Result<String> {
         guard let resourcePath = bundle.resourcePath else {
-            throw MochaException.fileNotFoundException
+            return .failure(.fileNotFoundException)
         }
-        return resourcePath.appendingPathComponent(filename)
+        return .success(resourcePath.appendingPathComponent(filename))
     }
 }
 
@@ -63,16 +63,17 @@ public extension BundleUtil {
 
 public extension BundleUtil {
     
-    public func read(_ filename: String?, ofType type: String?, withEncoding encoding: String.Encoding = .utf8) throws -> String {
-        let path = try self.path(of: filename, ofType: type)
-        return try read(atPath: path)
+    public func read(_ filename: String?, ofType type: String?, withEncoding encoding: String.Encoding = .utf8) -> Result<String> {
+        let path = self.path(of: filename, ofType: type)
+        return path.flatMap { read(atPath: $0) }
     }
     
-    public func read(atPath filePath: String, withEncoding encoding: String.Encoding = .utf8) throws -> String {
+    public func read(atPath filePath: String,
+                     withEncoding encoding: String.Encoding = .utf8) -> Result<String> {
         do {
-            return try String(contentsOfFile: filePath, encoding: encoding)
+            return try .success(String(contentsOfFile: filePath, encoding: encoding))
         } catch {
-            throw MochaException.genericException(message: "")
+            return .failure(.genericException(message: ""))
         }
     }
 }

--- a/MochaUtilities/Classes/Core/Utils/BundleUtil.swift
+++ b/MochaUtilities/Classes/Core/Utils/BundleUtil.swift
@@ -32,11 +32,15 @@ public class BundleUtil {
 public extension BundleUtil {
     
     public func file(_ filename: String?, ofType type: String?) -> Result<Data> {
-        let path = try self.path(of: filename, ofType: type)
-        guard let fileData = try? Data(contentsOf: URL(fileURLWithPath: path)) else {
-            return .failure(.fileNotFoundException)
+        let path = self.path(of: filename, ofType: type)
+        let fileData = path.flatMap { (value) -> Result<Data> in
+            do {
+                return try Result.success(Data(contentsOf: URL(fileURLWithPath: value)))
+            } catch {
+                return Result.failure(MochaException.fileNotFoundException)
+            }
         }
-        return .success(fileData)
+        return fileData
     }
 }
 

--- a/MochaUtilities/Classes/Core/Utils/DocumentsUtil.swift
+++ b/MochaUtilities/Classes/Core/Utils/DocumentsUtil.swift
@@ -20,14 +20,17 @@ public class DocumentsUtil {
 public extension DocumentsUtil {
     
     public func path(forDomainMask domainMask: FileManager.SearchPathDomainMask = .userDomainMask) -> Result<String> {
-        let documentPaths = NSSearchPathForDirectoriesInDomains(.documentDirectory, domainMask, true)
+        let documentPaths = NSSearchPathForDirectoriesInDomains(.documentDirectory,
+                                                                domainMask,
+                                                                true)
         if documentPaths.isEmpty {
             return .failure(.fileNotFoundException)
         }
         return .success(documentPaths[0])
     }
     
-    public func path(of filename: String?, with domainMask: FileManager.SearchPathDomainMask = .userDomainMask) -> Result<String> {
+    public func path(of filename: String?,
+                     with domainMask: FileManager.SearchPathDomainMask = .userDomainMask) -> Result<String> {
         guard let filename = filename, filename.isNotEmpty else {
             return .failure(.fileNotFoundException)
         }
@@ -212,11 +215,12 @@ public extension DocumentsUtil {
         }
         
         do {
-            try FileManager.default.createDirectory(atPath: path, withIntermediateDirectories: true, attributes: nil)
+            try FileManager.default.createDirectory(atPath: path,
+                                                    withIntermediateDirectories: true,
+                                                    attributes: nil)
             return .success()
         } catch {
             return .failure(.genericException(message: ""))
         }
     }
 }
-

--- a/MochaUtilities/Classes/Core/Utils/DocumentsUtil.swift
+++ b/MochaUtilities/Classes/Core/Utils/DocumentsUtil.swift
@@ -143,19 +143,15 @@ public extension DocumentsUtil {
         }
 
         let readResult = read(fullFileName)
-        
-        return readResult.flatMap { (value) -> Result<Void> in
-            let newText = "\(value)\n\(text)"
-            return write(newText, in: fullFileName)
+        return readResult.flatMap {
+            write("\($0)\n\(text)", in: fullFileName)
         }
     }
 
     public func append(_ text: String, atPath path: String) -> Result<Void> {
         let readResult = read(atPath: path)
-        
-        return readResult.flatMap { (currentText) -> Result<Void> in
-            let newText = "\(currentText)\n\(text)"
-            return write(newText, atPath: path)
+        return readResult.flatMap {
+            write("\($0)\n\(text)", atPath: path)
         }
     }
 }
@@ -175,8 +171,8 @@ public extension DocumentsUtil {
 
     public func remove(_ filename: String?) -> Result<Void> {
         let pathResult = self.path(of: filename)
-        return pathResult.flatMap { (path) -> Result<Void> in
-            return self.remove(atPath: path)
+        return pathResult.flatMap {
+            remove(atPath: $0)
         }
     }
 

--- a/MochaUtilities/Classes/Core/Utils/DocumentsUtil.swift
+++ b/MochaUtilities/Classes/Core/Utils/DocumentsUtil.swift
@@ -63,7 +63,7 @@ public extension DocumentsUtil {
     public func file(_ filename: String?) -> Result<Data> {
         let pathResult = self.path(of: filename)
         return pathResult.flatMap {
-            self.file(atPath: $0)
+            file(atPath: $0)
         }
     }
     
@@ -85,7 +85,7 @@ public extension DocumentsUtil {
                      withEncoding encoding: String.Encoding = .utf8) -> Result<String> {
         let pathResult = self.path(of: filename, with: .allDomainsMask)
         return pathResult.flatMap {
-            self.read(atPath: $0, withEncoding: encoding)
+            read(atPath: $0, withEncoding: encoding)
         }
     }
     

--- a/MochaUtilities/Classes/Network/Helpers/HttpHelper.swift
+++ b/MochaUtilities/Classes/Network/Helpers/HttpHelper.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-public typealias HttpCompletionHandler = (_ data: Data?, _ error: Error?) -> Void
+public typealias HttpCompletionHandler = (_ result: Result<Data>) -> Void
 
 public class HttpHelper: NSObject {
     
@@ -108,7 +108,7 @@ public class HttpHelper: NSObject {
     }
     
     private func handleDomainException(_ message: String) {
-        completionHandler?(nil, MochaException.domainException(message: message))
+        completionHandler?(.failure(.domainException(message: message)))
     }
     
     private func send(httpMethod: String) {
@@ -177,19 +177,20 @@ public class HttpHelper: NSObject {
             
             if let httpResponse = response as? HTTPURLResponse {
                 if httpResponse.statusCode == -1022 {
-                    self.completionHandler?(nil, MochaException.appSecurityTransportException)
+                    self.completionHandler?(.failure(.appSecurityTransportException))
                 } else if httpResponse.statusCode != 200 {
-                    self.completionHandler?(nil, error)
+//                    self.completionHandler?(.failure(error))
+//                    self.completionHandler?(nil, error)
                 }
             }
             
             if let error = error {
                 MochaLogger.log("Http error: \(error.localizedDescription)")
-                self.completionHandler?(nil, error)
+//                self.completionHandler?(nil, error)
             }
             
             if let data = data {
-                self.completionHandler?(data, nil)
+                self.completionHandler?(.success(data))
             }
         })
         
@@ -303,7 +304,7 @@ public extension HttpHelper {
         
         private var helper : HttpHelper
         
-        fileprivate init() {
+        public init() {
             helper = HttpHelper()
         }
         
@@ -311,58 +312,58 @@ public extension HttpHelper {
             helper.url = url
             return self
         }
-        
+
         public func completionHandler(_ handler: @escaping HttpCompletionHandler) -> Builder {
             helper.completionHandler = handler
             return self
         }
-        
+
         public func parameters(_ parameters: [String: Any]) -> Builder {
             helper.parameters = parameters
             return self
         }
-        
+
         public func contentType(_ contentType: String) -> Builder {
             helper.contentType = contentType
             return self
         }
-        
+
         public func timeout(_ timeout: TimeInterval) -> Builder {
             helper.timeout = timeout
             return self
         }
-        
+
         public func encoding(_ encoding: String.Encoding) -> Builder {
             helper.encoding = encoding
             return self
         }
-        
+
         public func header(_ header: [String: String]) -> Builder {
             helper.header = header
             return self
         }
-        
+
         public func basicAuth(username: String, password: String) -> Builder {
             helper.username = username
             helper.password = password
             return self
         }
-        
+
         public func certificate(_ certificate: Data?, with password: String? = nil) -> Builder {
             if certificate != nil {
                 helper.certificateMode = .publicKey
             }
-            
+
             helper.certificate = certificate
             helper.certificatePassword = password
             return self
         }
-        
+
         public func trustAll(_ trustAll: Bool) -> Builder {
             helper.trustAllSSL = trustAll
             return self
         }
-        
+
         public func hostDomain(_ hostDomain: String) -> Builder {
             helper.hostDomain = hostDomain
             return self


### PR DESCRIPTION
Creates an enum type `Result` to handle classes and/or methods which may return an error. Instead of throwing exceptions and causing an error handling hazard throughout the code, this `Result` type facilitates use in such situations.