### PR TITLE
HttpClient improvements

### DIFF
--- a/MochaUtilities/Basic/Enums/MochaError.swift
+++ b/MochaUtilities/Basic/Enums/MochaError.swift
@@ -15,6 +15,19 @@ public enum MochaError : Error {
         case unauthorized = 401
         case forbidden = 403
         case notFound = 404
+
+        var localizedDescription: String {
+            switch self {
+            case .badRequest:
+                return NSLocalizedString("Bad request", comment: "Bad request")
+            case .unauthorized:
+                return NSLocalizedString("Unauthorized", comment: "Unauthorized")
+            case .forbidden:
+                return NSLocalizedString("Forbidden", comment: "Forbidden")
+            case .notFound:
+                return NSLocalizedString("Not found", comment: "Not found")
+            }
+        }
     }
     
     case httpResponse(statusCode: Int, data: Data?)
@@ -26,6 +39,8 @@ public enum MochaError : Error {
     case notImplemented
     
     case serialization
+
+    case invalidContentType
     
     case descriptive(message: String)
     
@@ -46,6 +61,8 @@ extension MochaError: Equatable {
             return true
         case (.serialization, .serialization):
             return true
+        case (.invalidContentType, .invalidContentType):
+            return true
         case (.descriptive(let lmsg), .descriptive(let rmsg)):
             return lmsg == rmsg
         case (.error(let le), .error(let re)):
@@ -59,8 +76,32 @@ extension MochaError: CustomStringConvertible {
     
     public var description: String {
         switch self {
-        default:
-            return "Uncategorized MochaError"
+        case .httpResponse(let statusCode, _):
+            guard let code = HttpStatusCode(rawValue: statusCode) else {
+                return NSLocalizedString("Htpp response code is \(statusCode)",
+                    comment: "Generic status code error")
+            }
+
+            return code.localizedDescription
+        case .appSecurityTransport:
+            return NSLocalizedString("Invalid Security Transport settings for request",
+                                     comment: "Invalid Security Transport setting")
+        case .fileNotFound:
+            return NSLocalizedString("File not found",
+                                     comment: "File not found")
+        case .notImplemented:
+            return NSLocalizedString("Method not implemented",
+                                     comment: "Method not implemented")
+        case .serialization:
+            return NSLocalizedString("Serialization error",
+                                     comment: "Serialization error")
+        case .invalidContentType:
+            return NSLocalizedString("Invalid Content-Type for pamaremeters",
+                                     comment: "Invalid Content-Type")
+        case .descriptive(let message):
+            return message
+        case .error(let error):
+            return error.localizedDescription
         }
     }
 }


### PR DESCRIPTION
**General:**
- Added errors description for MochaError
- Added 'post' test in the HttpClientTest file

**HttpClient:**
- Removed forced optionals
- contentType is now a enum instead of an string
- changing the content type will now set the header with the correct content type